### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     }
     compile("org.apache.lucene:lucene-join:$luceneVersion")
     compile('joda-time:joda-time:2.3')
-    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.1'
+    compile group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
 
     //provided dependencies - do not copy into dist
     compile('org.codehaus.jackson:jackson-mapper-asl:1.9.2')


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/